### PR TITLE
[PORTAL46-8] Added config for allowed hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+venv
+*.pyc
+staticfiles
+.env
+db.sqlite3

--- a/portal46/settings.py
+++ b/portal46/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'a+3m^f_$@wdw#(vql-=$5z3dni4&@1*o1jo5de(isxd-y8r^wb'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['intense-sands-44841.herokuapp.com']
+ALLOWED_HOSTS = [os.environ['CURRENT_HOST']]
 
 
 # Application definition


### PR DESCRIPTION
# Purpose
The previous configuration requires the adding the app name to the ALLOWED_HOSTS list in the settings.py. This could become troublesome so instead of doing that, an environment variable (called CURRENT_HOST) is used and settings.py will just retrieve the value of that variable. The heroku app may need to be configured first in order for this to work.
 
A gitignore was also committed in this PR.

# Trello Ticket
[https://trello.com/c/LmHnxSvW/8-create-config-for-allowed-hosts](https://trello.com/c/LmHnxSvW/8-create-config-for-allowed-hosts)