### PR TITLE
[PORTAL46-7] Add config for DEBUG

### DIFF
--- a/portal46/settings.py
+++ b/portal46/settings.py
@@ -23,7 +23,15 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = 'a+3m^f_$@wdw#(vql-=$5z3dni4&@1*o1jo5de(isxd-y8r^wb'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ['DEBUG']
+
+if DEBUG is not None:
+  if DEBUG == '1':
+    DEBUG = True
+  else:
+    DEBUG = False
+else:
+  DEBUG = False
 
 ALLOWED_HOSTS = [os.environ['CURRENT_HOST']]
 


### PR DESCRIPTION
# Purpose
DEBUG should be turned-on in staging and turned-off in production. This process should be automated. A condition was added in the settings.py file where in it checks if there is a DEBUG environment variable set. The value of the DEBUG environment variable will determine if DEBUG should be on or off. If there is no DEBUG environment variable set, it is assumed that DEBUG is turned-off.

The staging environment is the only one that has a DEBUG environment variable defined. The production environment has none.

# Trello Ticket
[https://trello.com/c/0kDfHEgo/7-create-config-to-turn-off-debug-when-deployed-in-production](https://trello.com/c/0kDfHEgo/7-create-config-to-turn-off-debug-when-deployed-in-production)