### PR TITLE
[PORTAL46-30] Optimize get_access_token function for FB graph API

### DIFF
--- a/portal/fb_updates.py
+++ b/portal/fb_updates.py
@@ -27,12 +27,12 @@ class FbGroup(object):
     self.url = "https://www.facebook.com/" + id
 
 
-def get_access_token():
-  #ACCESS_TOKEN_URL = "https://graph.facebook.com/oauth/access_token?client_id=1831017710453000&client_secret=d0a5b177319e8ec5b3b414cdd544d953&grant_type=client_credentials"
-  #response = requests.get(ACCESS_TOKEN_URL)
-  #data = response.json()
-  #access_token = data['access_token']
-  return "1831017710453000|4BzULaLlMZiC3AgulMVkDKz6RkE"
+def get_access_token(fb_client_id, fb_client_secret):
+  ACCESS_TOKEN_URL = "https://graph.facebook.com/oauth/access_token?client_id={}&client_secret={}&grant_type=client_credentials".format(fb_client_id, fb_client_secret)
+  response = requests.get(ACCESS_TOKEN_URL)
+  data = response.json()
+  access_token = data['access_token']
+  return access_token
 
 
 def get_fb_group_posts(since, group, access_token):

--- a/portal/views.py
+++ b/portal/views.py
@@ -30,7 +30,7 @@ def subs_list(request):
 
 def updates(request):
   ## Get Facebook Updates
-  access_token = fb_updates.get_access_token()
+  access_token = fb_updates.get_access_token(settings.FB_CLIENT_ID, settings.FB_CLIENT_SECRET)
   target_date = fb_updates.get_target_date()
 
   fb_group_infos = []

--- a/portal46/settings.py
+++ b/portal46/settings.py
@@ -20,6 +20,10 @@ FERNET_CIPHER_KEY = b'hrLDgtcrQGqIQLCqUnMgwAf7kU_Fu1VmslETlMEmCRk='
 # OneHallyu settings
 ONEHALLYU_AUTH_KEY = '880ea6a14ea49e853634fbdc5015a024'
 
+# FB graph api credentials
+FB_CLIENT_ID='1831017710453000'
+FB_CLIENT_SECRET='d0a5b177319e8ec5b3b414cdd544d953'
+
 # Watched FB Pages
 # id:fb_page_name
 FB_GROUPS = {


### PR DESCRIPTION
# Purpose
Previously, the get_access_token function only returns a "fixed" string since it was observed that the string didn't really change for quite some time. However, it was stated in the FB graph api documentation that the access_token given will only have a lifetime of 60 days (for long-living access tokens since fb also provides short-living ones). Due to this, it was decided that this function will check ALWAYS for access token regardless if it is duplicate or not for security purposes.

# Trello Ticket
[https://trello.com/c/sIQFFf7G/30-optimize-getaccesstoken-for-fb](https://trello.com/c/sIQFFf7G/30-optimize-getaccesstoken-for-fb)